### PR TITLE
Stop dead torrents automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ python3 generate_string_session.py
 
 > Note: For Telegram uploads of folders, the bot creates a tar archive first, then uploads (video options apply only to actual video files).
 
+## Aria2 configuration
+- **BT_STOP_TIMEOUT**: (Optional) Seconds of zero download/upload activity before aria2 auto-stops a BitTorrent task (treats dead/stalled torrents). Default `600`. Override by exporting env var before start (e.g., `BT_STOP_TIMEOUT=900`).
+
 ## Getting Google OAuth API credential file
 
 - Visit the [Google Cloud Console](https://console.developers.google.com/apis/credentials)

--- a/aria.bat
+++ b/aria.bat
@@ -1,1 +1,2 @@
-aria2c --enable-rpc --rpc-listen-all=false --rpc-listen-port 6800  --max-connection-per-server=10 --rpc-max-request-size=1024M --seed-time=0.01 --min-split-size=10M --follow-torrent=mem --split=10 --daemon=true --allow-overwrite=true
+IF "%BT_STOP_TIMEOUT%"=="" set BT_STOP_TIMEOUT=600
+aria2c --enable-rpc --rpc-listen-all=false --rpc-listen-port 6800  --max-connection-per-server=10 --rpc-max-request-size=1024M --seed-time=0.01 --min-split-size=10M --follow-torrent=mem --split=10 --bt-stop-timeout=%BT_STOP_TIMEOUT% --daemon=true --allow-overwrite=true

--- a/aria.sh
+++ b/aria.sh
@@ -1,7 +1,9 @@
-export MAX_DOWNLOAD_SPEED=0
-export MAX_CONCURRENT_DOWNLOADS=3
+export MAX_DOWNLOAD_SPEED=${MAX_DOWNLOAD_SPEED:-0}
+export MAX_CONCURRENT_DOWNLOADS=${MAX_CONCURRENT_DOWNLOADS:-3}
+export BT_STOP_TIMEOUT=${BT_STOP_TIMEOUT:-600}
 aria2c --enable-rpc --rpc-listen-all=false --rpc-listen-port 6800 \
   --max-connection-per-server=10 --rpc-max-request-size=1024M \
-  --seed-time=0.01 --min-split-size=10M --follow-torrent=mem --split=10 \
-   --daemon=true --allow-overwrite=true --max-overall-download-limit=$MAX_DOWNLOAD_SPEED \
-   --max-overall-upload-limit=1K --max-concurrent-downloads=$MAX_CONCURRENT_DOWNLOADS
+    --seed-time=0.01 --min-split-size=10M --follow-torrent=mem --split=10 \
+    --bt-stop-timeout=$BT_STOP_TIMEOUT \
+    --daemon=true --allow-overwrite=true --max-overall-download-limit=$MAX_DOWNLOAD_SPEED \
+    --max-overall-upload-limit=1K --max-concurrent-downloads=$MAX_CONCURRENT_DOWNLOADS

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -63,6 +63,7 @@ download_dict = {}
 # Stores list of users and chats the bot is authorized to use in
 redis_client = None
 AUTHORIZED_CHATS = set()
+WAITING_FOR_TOKEN_PICKLE = False
 
 redis_authorised_chats_key = 'bots:authorized_chats'
 def redis_init():

--- a/bot/helper/mirror_utils/download_utils/aioaria2_adapter.py
+++ b/bot/helper/mirror_utils/download_utils/aioaria2_adapter.py
@@ -58,6 +58,41 @@ class _AioAria2Download:
 		return f"{get_readable_file_size(speed)}/s"
 
 	@property
+	def download_speed(self) -> int:
+		self._update()
+		return int(self._last_status.get("downloadSpeed", 0))
+
+	def progress_string(self) -> str:
+		self._update()
+		total = int(self._last_status.get("totalLength", 0))
+		completed = int(self._last_status.get("completedLength", 0))
+		if total <= 0:
+			return "0%"
+		percent = int(completed * 100 / total)
+		percent = max(0, min(100, percent))
+		return f"{percent}%"
+
+	@property
+	def status(self) -> str:
+		self._update()
+		return str(self._last_status.get("status") or "")
+
+	@property
+	def error_code(self) -> Optional[int]:
+		self._update()
+		code = self._last_status.get("errorCode")
+		try:
+			return int(code) if code is not None else None
+		except Exception:
+			return None
+
+	@property
+	def error_message(self) -> str:
+		self._update()
+		msg = self._last_status.get("errorMessage")
+		return str(msg) if msg else ""
+
+	@property
 	def name(self) -> str:
 		self._update()
 		bt = self._last_status.get("bittorrent") or {}

--- a/bot/helper/mirror_utils/status_utils/aria_download_status.py
+++ b/bot/helper/mirror_utils/status_utils/aria_download_status.py
@@ -21,6 +21,7 @@ class AriaDownloadStatus(Status):
         self.last = None
         self.is_waiting = False
         self.is_extracting = False
+        self.cancelled_by_user = False
 
     def __update(self):
         self.__download = get_download(self.__gid)
@@ -95,6 +96,7 @@ class AriaDownloadStatus(Status):
 
     def cancel_download(self):
         LOGGER.info(f"Cancelling Download: {self.name()}")
+        self.cancelled_by_user = True
         download = self.aria_download()
         if download.is_waiting:
             aria2.remove([download])

--- a/config_sample.env
+++ b/config_sample.env
@@ -24,3 +24,6 @@ MEGA_PASSWORD = ""
 REDIS_HOST = ""
 REDIS_PORT = 6397
 REDIS_PASSWORD = ""
+# Optional: seconds of zero BT activity before aria2 stops a torrent (treat dead/stalled)
+# Default is 600 if unset; can also export BT_STOP_TIMEOUT in the shell
+# BT_STOP_TIMEOUT = 600


### PR DESCRIPTION
Add `bt-stop-timeout` to aria2 configuration to automatically stop dead torrents.

---
<a href="https://cursor.com/background-agent?bcId=bc-79afa93f-2211-44c5-84c6-20d96873c6e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-79afa93f-2211-44c5-84c6-20d96873c6e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

